### PR TITLE
Add possibility to move player using arrows

### DIFF
--- a/asm/sokoban.asm
+++ b/asm/sokoban.asm
@@ -45,7 +45,15 @@ kbaction:
 	mov dl, 0						;
 	mov dh, 1						;
 	je kbaction_match				;
+	cmp ah, 0x4b					;Player - move left(arrow)
+	mov dl, 0						;
+	mov dh, 1						;
+	je kbaction_match				;
 	cmp al, 'd'						;Player - move right
+	mov dl, 2						;
+	mov dh, 1						;
+	je kbaction_match				;
+	cmp ah, 0x4d					;Player - move right(arrow)
 	mov dl, 2						;
 	mov dh, 1						;
 	je kbaction_match				;
@@ -53,7 +61,15 @@ kbaction:
 	mov dl, 1						;
 	mov dh, 0						;
 	je kbaction_match				;
+	cmp ah, 0x48					;Player - move up(arrow)
+	mov dl, 1						;
+	mov dh, 0						;
+	je kbaction_match				;
 	cmp al, 's'						;Player - move down
+	mov dl, 1						;
+	mov dh, 2						;
+	je kbaction_match				;
+	cmp ah, 0x50					;Player - move down(arrow)
 	mov dl, 1						;
 	mov dh, 2						;
 	je kbaction_match				;


### PR DESCRIPTION
In order to move player more easily (numerous players don't like using WASD),  I've decided to add possibility to move player using arrows to your game. It use to compare BIOS scancode, which is stored in upper part of ax.